### PR TITLE
chore(RHTAPWATCH-818): Enable source build in both pipelines

### DIFF
--- a/.tekton/project-controller-pull-request.yaml
+++ b/.tekton/project-controller-pull-request.yaml
@@ -109,7 +109,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/project-controller-push.yaml
+++ b/.tekton/project-controller-push.yaml
@@ -106,7 +106,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string


### PR DESCRIPTION
We will need to update the pipeline to build source images as per Red Hat policy so enabling it in both pipelines.