### PR TITLE
chore(RHTAPWATCH-819): Resolve kube-lint errors

### DIFF
--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,8 @@
+checks:
+
+  # include explicitly adds checks, by name. You can reference any of the built-in checks.
+  # Note that customChecks defined above are included automatically.
+  include: []
+  # exclude explicitly excludes checks, by name. exclude has the highest priority: if a check is
+  # in exclude, then it is not considered, even if it is in include as well.
+  exclude: []

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -11,6 +11,7 @@ spec:
       containers:
       - name: kube-rbac-proxy
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:
@@ -33,6 +34,8 @@ spec:
             cpu: 5m
             memory: 64Mi
       - name: manager
+        securityContext:
+          readOnlyRootFilesystem: true
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,4 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: default-route-openshift-image-registry.apps-crc.testing/project-controller-system/project-controller
+  newName: konflux-project-controller


### PR DESCRIPTION
When adding project-controller component to the infra- deployments repository it is failing due to kube-linter issues.