### PR TITLE
fix(RHTAPWATCH-1166): RBAC 4 ImgRepos & IntgTstScn

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,4 @@
 [tools]
 go = "1.21.10"
 kubectl = "1.30.2"
+"go:github.com/onsi/ginkgo/v2/ginkgo" = "2.14.0"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,6 +29,30 @@ rules:
   - update
   - watch
 - apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - imagerepositories
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - integrationtestscenarios
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - projctl.konflux.dev
   resources:
   - projectdevelopmentstreams

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 toolchain go1.21.10
 
 require (
+	github.com/gertd/go-pluralize v0.2.1
 	github.com/go-logr/logr v1.4.2
 	github.com/konflux-ci/application-api v0.0.0-20240527211352-be061932d497
 	github.com/konflux-ci/image-controller v0.0.0-20240712153454-e138500d2d42

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/gertd/go-pluralize v0.2.1 h1:M3uASbVjMnTsPb0PNqg+E/24Vwigyo/tvyMTtAlLgiA=
+github.com/gertd/go-pluralize v0.2.1/go.mod h1:rbYaKDbsXxmRfr8uygAEKhOWsjyrrqrkHVpZvoOp8zk=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/internal/controller/projectdevelopmentstream_controller_test.go
+++ b/internal/controller/projectdevelopmentstream_controller_test.go
@@ -36,6 +36,7 @@ import (
 
 	projctlv1beta1 "github.com/konflux-ci/project-controller/api/v1beta1"
 	"github.com/konflux-ci/project-controller/internal/ownership"
+	"github.com/konflux-ci/project-controller/pkg/testhelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -105,12 +106,10 @@ var _ = Describe("ProjectDevelopmentStream Controller", func() {
 })
 
 func resourceFromFile(fname string, resource client.Object) {
-	f, err := os.Open(filepath.Join("..", "..", "config", "samples", fname))
-	Expect(err).NotTo(HaveOccurred())
-	defer func() { _ = f.Close() }()
-	buf, err := io.ReadAll(f)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(yaml.UnmarshalStrict(buf, resource)).To(Succeed())
+	testhelpers.ResourceFromFile(
+		filepath.Join("..", "..", "config", "samples", fname),
+		resource,
+	)
 }
 
 func applyFile(ctx context.Context, k8sClient client.Client, fname string, ns string) {

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -14,6 +14,8 @@ import (
 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=imagerepositories,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=integrationtestscenarios,verbs=get;list;watch;create;update;patch;delete
 
 // List of resource types supported by templates and various details about how
 // to instantiate resources of those types. The list order determines the order

--- a/internal/template/resources_test.go
+++ b/internal/template/resources_test.go
@@ -1,0 +1,66 @@
+package template
+
+import (
+	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apischema "k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/gertd/go-pluralize"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+
+	"github.com/konflux-ci/project-controller/pkg/testhelpers"
+)
+
+var _ = Describe("Resources", func() {
+	Describe("supportedResourceTypes lists resources supported in templates", func() {
+		Describe("Each supported resource type should also have a matching RBAC rule", Ordered, func() {
+			var managerRole rbacv1.ClusterRole
+			var plz *pluralize.Client
+
+			var allSupportedAPIs []apischema.GroupVersionKind
+			for _, srt := range supportedResourceTypes {
+				allSupportedAPIs = append(allSupportedAPIs, srt.supportedAPIs...)
+			}
+			allSupportedAPIEntries := make([]TableEntry, 0, len(allSupportedAPIs))
+			for _, gvk := range allSupportedAPIs {
+				allSupportedAPIEntries = append(allSupportedAPIEntries, Entry(nil, gvk))
+			}
+
+			BeforeAll(func() {
+				plz = pluralize.NewClient()
+			})
+
+			BeforeAll(func() {
+				testhelpers.ResourceFromFile("../../config/rbac/role.yaml", &managerRole)
+				Expect(managerRole.Rules).ShouldNot(BeEmpty())
+			})
+
+			DescribeTable(
+				"For each supported API GVK",
+				func(supportedAPI apischema.GroupVersionKind) {
+					Expect(managerRole.Rules).To(ContainElement(
+						MatchFields(IgnoreExtras, Fields{
+							"APIGroups":     ContainElement(supportedAPI.Group),
+							"Resources":     ContainElement(plz.Plural(strings.ToLower(supportedAPI.Kind))),
+							"ResourceNames": BeEmpty(),
+							"Verbs": ContainElements(
+								"create",
+								"delete",
+								"get",
+								"list",
+								"patch",
+								"update",
+								"watch",
+							),
+						}),
+					))
+				},
+				allSupportedAPIEntries,
+			)
+		})
+	})
+})

--- a/internal/template/template_suite_test.go
+++ b/internal/template/template_suite_test.go
@@ -1,0 +1,13 @@
+package template_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTemplate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Template Suite")
+}

--- a/pkg/testhelpers/resourcefromfile.go
+++ b/pkg/testhelpers/resourcefromfile.go
@@ -1,0 +1,20 @@
+package testhelpers
+
+import (
+	"io"
+	"os"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	g "github.com/onsi/gomega"
+)
+
+func ResourceFromFile(path string, resource client.Object) {
+	f, err := os.Open(path)
+	g.Expect(err).NotTo(g.HaveOccurred())
+	defer func() { _ = f.Close() }()
+	buf, err := io.ReadAll(f)
+	g.Expect(err).NotTo(g.HaveOccurred())
+	g.Expect(yaml.UnmarshalStrict(buf, resource)).To(g.Succeed())
+}


### PR DESCRIPTION
Fix misssing RBAC rules for `ImageRepository` and
`IntegrationTestScenario` resources.

Also add tests so that we don't miss such rules next time.