### PR TITLE
fix(RHTAPWATCH-1174): 'cannot set blockOwnerDeletion' error

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,5 @@
 [tools]
 go = "1.21.10"
 kubectl = "1.30.2"
-"go:github.com/onsi/ginkgo/v2/ginkgo" = "2.14.0"
+"go:github.com/onsi/ginkgo/v2/ginkgo" = "2.19.0"
+kind = "0.22.0"

--- a/.mise.toml
+++ b/.mise.toml
@@ -3,3 +3,8 @@ go = "1.21.10"
 kubectl = "1.30.2"
 "go:github.com/onsi/ginkgo/v2/ginkgo" = "2.19.0"
 kind = "0.22.0"
+crc = "2.39.0"
+
+[plugins]
+# Need to use Barak's fork until PR#8 is merged upstream
+crc = 'https://github.com/ifireball/asdf-crc#revert-bkorren-fix'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,30 @@
 # Contributing to this project
 
+## Automated testing with CRC
+
+After installing CRC and starting a cluster, we can use the `kubectl` context 
+already prepared for us to connect to the cluster.
+
+    kubectl config use-context crc-admin
+
+This should allow us to run commands like:
+
+    kubectl cluster-info
+
+The output should resemble toe following:
+
+    Kubernetes control plane is running at https://api.crc.testing:6443
+
+    To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
+
+Now we can run our tests:
+
+    USE_EXISTING_CLUSTER=true KEEP_TEST_NAMESPACES=true ginkgo run -v internal/controller
+
+Since we have `KEEP_TEST_NAMESPACES` set to `true` we can find namespaces with 
+names like `test-ns-1-1234` in the cluster once the tests are done and inspect
+the obejcts that were created.
+
 ## Manual testing with CRC
 
 Login to CRC as *kubeadmin*. The password would be displayed when bringing up

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ This should allow us to run commands like:
 
     kubectl cluster-info
 
-The output should resemble toe following:
+The output should resemble the following:
 
     Kubernetes control plane is running at https://api.crc.testing:6443
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,12 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - applications/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
   - components
   verbs:
   - create

--- a/internal/controller/projectdevelopmentstream_controller_test.go
+++ b/internal/controller/projectdevelopmentstream_controller_test.go
@@ -54,7 +54,7 @@ var _ = Describe("ProjectDevelopmentStream Controller", func() {
 				testNsN = types.NamespacedName{Namespace: testNs, Name: pdsName}
 
 				for _, resFile := range resFiles {
-					applyFile(ctx, k8sClient, resFile, testNs)
+					applySampleFile(ctx, k8sClient, resFile, testNs)
 				}
 			})
 
@@ -62,8 +62,8 @@ var _ = Describe("ProjectDevelopmentStream Controller", func() {
 				var err error
 
 				controllerReconciler := &ProjectDevelopmentStreamReconciler{
-					Client: k8sClient,
-					Scheme: k8sClient.Scheme(),
+					Client: saClient,
+					Scheme: saClient.Scheme(),
 				}
 
 				By("Setting the owner reference")
@@ -113,18 +113,12 @@ var _ = Describe("ProjectDevelopmentStream Controller", func() {
 	)
 })
 
-func resourceFromFile(fname string, resource client.Object) {
-	testhelpers.ResourceFromFile(
+func applySampleFile(ctx context.Context, k8sClient client.Client, fname string, ns string) {
+	testhelpers.ApplyFile(
+		ctx, k8sClient, 
 		filepath.Join("..", "..", "config", "samples", fname),
-		resource,
+		ns,
 	)
-}
-
-func applyFile(ctx context.Context, k8sClient client.Client, fname string, ns string) {
-	var res unstructured.Unstructured
-	resourceFromFile(fname, &res)
-	res.SetNamespace(ns)
-	Expect(k8sClient.Create(ctx, &res)).To(Succeed())
 }
 
 func setupTestNamespace(ctx context.Context, k8sClient client.Client) string {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -36,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	projctlv1beta1 "github.com/konflux-ci/project-controller/api/v1beta1"
 	"github.com/konflux-ci/project-controller/pkg/testhelpers"
@@ -136,7 +136,7 @@ var _ = AfterSuite(func() {
 func setupSystemNamespace(ctx context.Context, client client.Client) {
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "system"}}
 	Expect(client.Create(ctx, &ns)).To(Or(
-		Succeed(), 
+		Succeed(),
 		MatchError(apierrors.IsAlreadyExists, "IsAlreadyExists"),
 	))
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -28,14 +28,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	projctlv1beta1 "github.com/konflux-ci/project-controller/api/v1beta1"
 	"github.com/konflux-ci/project-controller/pkg/testhelpers"
@@ -134,16 +135,19 @@ var _ = AfterSuite(func() {
 
 func setupSystemNamespace(ctx context.Context, client client.Client) {
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "system"}}
-	Expect(client.Create(ctx, &ns)).To(Succeed())
+	Expect(client.Create(ctx, &ns)).To(Or(
+		Succeed(), 
+		MatchError(apierrors.IsAlreadyExists, "IsAlreadyExists"),
+	))
 }
 
 func setupServiceAccount(ctx context.Context, client client.Client) {
 	saFiles := []string{"role", "service_account", "role_binding"}
 	for _, saFile := range saFiles {
 		testhelpers.ApplyFile(
-			ctx, client, 
+			ctx, client,
 			filepath.Join("..", "..", "config", "rbac", fmt.Sprintf("%s.yaml", saFile)),
-			 "system",
+			"system",
 		)
 	}
 }

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -13,6 +13,7 @@ import (
 )
 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/finalizers,verbs=update
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=imagerepositories,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=integrationtestscenarios,verbs=get;list;watch;create;update;patch;delete

--- a/internal/template/resources_test.go
+++ b/internal/template/resources_test.go
@@ -39,7 +39,6 @@ var _ = Describe("Resources", func() {
 				allAPIsWFinAccessNdedEntries = append(allAPIsWFinAccessNdedEntries, Entry(nil, gvk))
 			}
 
-
 			BeforeAll(func() {
 				plz = pluralize.NewClient()
 			})
@@ -76,12 +75,12 @@ var _ = Describe("Resources", func() {
 				func(api apischema.GroupVersionKind) {
 					Expect(managerRole.Rules).To(ContainElement(
 						MatchFields(IgnoreExtras, Fields{
-							"APIGroups":     ContainElement(api.Group),
-							"Resources":     ContainElement(fmt.Sprintf(
+							"APIGroups": ContainElement(api.Group),
+							"Resources": ContainElement(fmt.Sprintf(
 								"%s/finalizers", plz.Plural(strings.ToLower(api.Kind))),
 							),
 							"ResourceNames": BeEmpty(),
-							"Verbs": ContainElements("update"),
+							"Verbs":         ContainElements("update"),
 						}),
 					))
 				},

--- a/internal/template/resources_test.go
+++ b/internal/template/resources_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"fmt"
 	"strings"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -22,13 +23,22 @@ var _ = Describe("Resources", func() {
 			var plz *pluralize.Client
 
 			var allSupportedAPIs []apischema.GroupVersionKind
+			var allAPIsWFinalizerAccessNeeded []apischema.GroupVersionKind
 			for _, srt := range supportedResourceTypes {
 				allSupportedAPIs = append(allSupportedAPIs, srt.supportedAPIs...)
+				if srt.ownerDeletionBlocked || srt.ownerIsController {
+					allAPIsWFinalizerAccessNeeded = append(allAPIsWFinalizerAccessNeeded, srt.ownerAPI)
+				}
 			}
 			allSupportedAPIEntries := make([]TableEntry, 0, len(allSupportedAPIs))
 			for _, gvk := range allSupportedAPIs {
 				allSupportedAPIEntries = append(allSupportedAPIEntries, Entry(nil, gvk))
 			}
+			allAPIsWFinAccessNdedEntries := make([]TableEntry, 0, len(allAPIsWFinalizerAccessNeeded))
+			for _, gvk := range allAPIsWFinalizerAccessNeeded {
+				allAPIsWFinAccessNdedEntries = append(allAPIsWFinAccessNdedEntries, Entry(nil, gvk))
+			}
+
 
 			BeforeAll(func() {
 				plz = pluralize.NewClient()
@@ -60,6 +70,22 @@ var _ = Describe("Resources", func() {
 					))
 				},
 				allSupportedAPIEntries,
+			)
+			DescribeTable(
+				"For each API GVK we need finalizer update permissions on",
+				func(api apischema.GroupVersionKind) {
+					Expect(managerRole.Rules).To(ContainElement(
+						MatchFields(IgnoreExtras, Fields{
+							"APIGroups":     ContainElement(api.Group),
+							"Resources":     ContainElement(fmt.Sprintf(
+								"%s/finalizers", plz.Plural(strings.ToLower(api.Kind))),
+							),
+							"ResourceNames": BeEmpty(),
+							"Verbs": ContainElements("update"),
+						}),
+					))
+				},
+				allAPIsWFinAccessNdedEntries,
 			)
 		})
 	})

--- a/pkg/testhelpers/applyfile.go
+++ b/pkg/testhelpers/applyfile.go
@@ -20,6 +20,7 @@ func ApplyFile(ctx context.Context, k8sClient client.Client, path string, ns str
 	err := k8sClient.Create(ctx, res)
 	if !apierrors.IsAlreadyExists(err) {
 		g.Expect(err).NotTo(g.HaveOccurred())
+		return
 	}
 	res = fileRes.DeepCopy()
 	g.Expect(k8sClient.Patch(

--- a/pkg/testhelpers/applyfile.go
+++ b/pkg/testhelpers/applyfile.go
@@ -5,9 +5,9 @@ import (
 
 	g "github.com/onsi/gomega"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func ApplyFile(ctx context.Context, k8sClient client.Client, path string, ns string) {
@@ -23,8 +23,8 @@ func ApplyFile(ctx context.Context, k8sClient client.Client, path string, ns str
 	}
 	res = fileRes.DeepCopy()
 	g.Expect(k8sClient.Patch(
-		ctx, res, 
-		client.Apply, 
+		ctx, res,
+		client.Apply,
 		client.FieldOwner("test-suite"), client.ForceOwnership,
 	)).To(g.Succeed())
 }

--- a/pkg/testhelpers/applyfile.go
+++ b/pkg/testhelpers/applyfile.go
@@ -1,0 +1,17 @@
+package testhelpers
+
+import (
+	"context"
+
+	g "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func ApplyFile(ctx context.Context, k8sClient client.Client, path string, ns string) {
+	var res unstructured.Unstructured
+	ResourceFromFile(path, &res)
+	res.SetNamespace(ns)
+	g.Expect(k8sClient.Create(ctx, &res)).To(g.Succeed())
+}


### PR DESCRIPTION
We had a failure scenario  that was only happenning on OpenShift where
we couldn't set the `blockOwnerDeletion` field in `ownerReferences`
lists if the controller did not have permissions to update finalizers on
the referenced owner object kind.

Here we add the needed RBAK permissions as well as added a test that
would help prevent causing the same issue in the future.

Unfurtunately we can't reproduce the issue directly in envtest as it
seems to be unique to OpenShift. Commits in this PR also make changes to enable running the unit tests on OpenShift with the right service account and role settings.