### PR TITLE
feat(RHTAPWATCH-1192): Server-Side-Apply template

### DIFF
--- a/config/samples/appstudio_v1alpha1_comp.yaml
+++ b/config/samples/appstudio_v1alpha1_comp.yaml
@@ -1,0 +1,21 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  name: "cool-comp1-5-5-0"
+  annotations:
+    applicationFailCounter: "5"  
+  finalizers:
+    - test.appstudio.openshift.io/component
+    - image-controller.appstudio.openshift.io/image-repository
+    - image-registry-secret-sa-link.component.appstudio.openshift.io/finalizer
+    - pac.component.appstudio.openshift.io/finalizer  
+spec:
+  application: "cool-app-5-5-0"
+  componentName: "cool-comp1-5-5-0"
+  containerImage: "meyreg.io/cool-app/cool-comp1:v5-5-0-acbdef1"
+  source:
+    git:
+      context: "./"
+      dockerfileUrl: "Dockerfile"
+      revision: "wrong"
+      url: git@github.com:example/comp1.git

--- a/config/samples/projctl_v1beta1_pds_w_existing_comp.yaml
+++ b/config/samples/projctl_v1beta1_pds_w_existing_comp.yaml
@@ -1,0 +1,11 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: ProjectDevelopmentStream
+metadata:
+  name: pds-sample-w-existing-comp
+spec:
+  project: project-sample
+  template:
+    name: pdst-sample-w-existing-comp
+    values:
+    - name: version
+      value: "5.5.0"

--- a/config/samples/projctl_v1beta1_pds_w_existing_comp_exp_results.yaml
+++ b/config/samples/projctl_v1beta1_pds_w_existing_comp_exp_results.yaml
@@ -1,0 +1,36 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: "cool-app-5-5-0"
+  ownerReferences:
+  - apiVersion: "projctl.konflux.dev/v1beta1"
+    kind: "ProjectDevelopmentStream"
+    name: "pds-sample-w-existing-comp"
+spec:
+  displayName: "Cool App 5.5.0"
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  name: "cool-comp1-5-5-0"
+  ownerReferences:
+  - apiVersion: "appstudio.redhat.com/v1alpha1"
+    kind: "Application"
+    name: "cool-app-5-5-0"
+  annotations:
+    applicationFailCounter: "0"    
+  finalizers:
+    - test.appstudio.openshift.io/component
+    - image-controller.appstudio.openshift.io/image-repository
+    - image-registry-secret-sa-link.component.appstudio.openshift.io/finalizer
+    - pac.component.appstudio.openshift.io/finalizer  
+spec:
+  application: "cool-app-5-5-0"
+  componentName: "cool-comp1-5-5-0"
+  containerImage: "meyreg.io/cool-app/cool-comp1:v5-5-0-acbdef1"  
+  source:
+    git:
+      context: "./"
+      dockerfileUrl: "Dockerfile"
+      revision: "5.5.0"
+      url: git@github.com:example/comp1.git

--- a/config/samples/projctl_v1beta1_pdst_w_existing_comp.yaml
+++ b/config/samples/projctl_v1beta1_pdst_w_existing_comp.yaml
@@ -1,0 +1,36 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: ProjectDevelopmentStreamTemplate
+metadata:
+  name: pdst-sample-w-existing-comp
+spec:
+  project: project-sample
+  variables:
+  - name: version
+    description: A version number for the new development stream
+  - name: versionName
+    defaultValue: "{{hyphenize .version}}"
+    description: A resource-name friendly version value
+
+  resources:
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Application
+    metadata:
+      name: "cool-app-{{.versionName}}"
+    spec:
+      displayName: "Cool App {{.version}}"
+
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      name: "cool-comp1-{{.versionName}}"
+      annotations:
+        applicationFailCounter: "0"      
+    spec:
+      application: "cool-app-{{.versionName}}"
+      componentName: "cool-comp1-{{.versionName}}"
+      source:
+        git:
+          context: "./"
+          dockerfileUrl: "Dockerfile"
+          revision: "{{.version}}"
+          url: git@github.com:example/comp1.git

--- a/internal/controller/projectdevelopmentstream_controller_test.go
+++ b/internal/controller/projectdevelopmentstream_controller_test.go
@@ -111,6 +111,15 @@ var _ = Describe("ProjectDevelopmentStream Controller", func() {
 			"projctl_v1beta1_pdst_w_relpln.yaml",
 			"projctl_v1beta1_pds_w_relpln.yaml",
 		),
+		Entry(
+			"Existing Component resource",
+			"pds-sample-w-existing-comp",
+			"projctl_v1beta1_pds_w_existing_comp_exp_results.yaml",
+			"appstudio_v1alpha1_comp.yaml",
+			"projctl_v1beta1_project.yaml",
+			"projctl_v1beta1_pdst_w_existing_comp.yaml",
+			"projctl_v1beta1_pds_w_existing_comp.yaml",
+		),
 	)
 })
 
@@ -185,7 +194,7 @@ func dropUncomparableMetadata(obj *unstructured.Unstructured) {
 
 	emdm := emd.(map[string]interface{})
 	nmd := make(map[string]interface{})
-	for _, key := range []string{"ownerReferences", "annotations", "labels", "name", "namespace"} {
+	for _, key := range []string{"ownerReferences", "annotations", "labels", "name", "namespace", "finalizers"} {
 		if v, ok := emdm[key]; ok {
 			nmd[key] = v
 		}

--- a/pkg/testhelpers/applyfile.go
+++ b/pkg/testhelpers/applyfile.go
@@ -5,24 +5,14 @@ import (
 
 	g "github.com/onsi/gomega"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func ApplyFile(ctx context.Context, k8sClient client.Client, path string, ns string) {
-	var res, fileRes *unstructured.Unstructured
-	fileRes = new(unstructured.Unstructured)
-	ResourceFromFile(path, fileRes)
-	fileRes.SetNamespace(ns)
-	// Keep a clean copy of the data from the file
-	res = fileRes.DeepCopy()
-	err := k8sClient.Create(ctx, res)
-	if !apierrors.IsAlreadyExists(err) {
-		g.Expect(err).NotTo(g.HaveOccurred())
-		return
-	}
-	res = fileRes.DeepCopy()
+	res := new(unstructured.Unstructured)
+	ResourceFromFile(path, res)
+	res.SetNamespace(ns)
 	g.Expect(k8sClient.Patch(
 		ctx, res,
 		client.Apply,


### PR DESCRIPTION
Use server-side-apply for templated objects instead of create or update operations. This causes fields on existing resources that do not have values specified in the template to be preserved.

This make the controller not clobber fields such as `spec.containarImage` and `metadata.finalizers` that are set by other controllers unless values are explicitly set in the template.