### PR TITLE
Nudges-support

### DIFF
--- a/config/samples/projctl_v1beta1_pds_w_tmp_vars_exp_results.yaml
+++ b/config/samples/projctl_v1beta1_pds_w_tmp_vars_exp_results.yaml
@@ -52,6 +52,9 @@ spec:
       dockerfileUrl: "Dockerfile"
       revision: "1.0.0"
       url: git@github.com:example/comp1.git
+  build-nudges-ref:
+  - "cool-comp2-1-0-0"
+  - "other-comp"
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Component

--- a/config/samples/projctl_v1beta1_projectdevelopmentstreamtemplate.yaml
+++ b/config/samples/projctl_v1beta1_projectdevelopmentstreamtemplate.yaml
@@ -62,6 +62,9 @@ spec:
           dockerfileUrl: "{{.cool_comp1_dockerfileUrl}}"
           revision: "{{.cool_comp1_revision}}"
           url: git@github.com:example/comp1.git
+      build-nudges-ref:
+      - "cool-comp2-{{.versionName}}"
+      - "other-comp"
 
   - apiVersion: appstudio.redhat.com/v1alpha1
     kind: Component

--- a/internal/template/execute.go
+++ b/internal/template/execute.go
@@ -1,0 +1,27 @@
+package template
+
+import (
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+var nameFieldInvalidCharPattern = regexp.MustCompile("[^a-z0-9]")
+var templateFuncs = template.FuncMap{
+	"hyphenize": func(str string) string {
+		return nameFieldInvalidCharPattern.ReplaceAllString(str, "-")
+	},
+}
+
+// Execute the template given as a string and return the result as a string
+func executeTemplate(templateStr string, values map[string]string) (string, error) {
+	theTemplate, err := template.New("").Funcs(templateFuncs).Parse(templateStr)
+	if err != nil {
+		return "", err
+	}
+	var valueBuf strings.Builder
+	if err := theTemplate.Execute(&valueBuf, values); err != nil {
+		return "", err
+	}
+	return valueBuf.String(), nil
+}

--- a/internal/template/execute_internal_test.go
+++ b/internal/template/execute_internal_test.go
@@ -1,0 +1,27 @@
+package template
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeTable(
+	"Execute applies a template string",
+	func(template string, values map[string]string, expected string) {
+		out, err := executeTemplate(template, values)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(Equal(expected))
+	},
+	Entry(
+		"for simple template and value",
+		"{{.version}}",
+		map[string]string{"version": "1.2.3"},
+		"1.2.3",
+	),
+	Entry(
+		"and suports the hyphenize function",
+		"{{.version|hyphenize}}",
+		map[string]string{"version": "1.2.3"},
+		"1-2-3",
+	),
+)

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"text/template"
 
 	projctlv1beta1 "github.com/konflux-ci/project-controller/api/v1beta1"
 	"github.com/konflux-ci/project-controller/internal/ownership"
@@ -279,24 +278,4 @@ func getVarValues(
 		}
 	}
 	return
-}
-
-var nameFieldInvalidCharPattern = regexp.MustCompile("[^a-z0-9]")
-var templateFuncs = template.FuncMap{
-	"hyphenize": func(str string) string {
-		return nameFieldInvalidCharPattern.ReplaceAllString(str, "-")
-	},
-}
-
-// Execute the template given as a string and return the result as a string
-func executeTemplate(templateStr string, values map[string]string) (string, error) {
-	theTemplate, err := template.New("").Funcs(templateFuncs).Parse(templateStr)
-	if err != nil {
-		return "", err
-	}
-	var valueBuf strings.Builder
-	if err := theTemplate.Execute(&valueBuf, values); err != nil {
-		return "", err
-	}
-	return valueBuf.String(), nil
 }

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -61,6 +61,7 @@ var supportedResourceTypes = []struct {
 			{"metadata", "name"},
 			{"spec", "application"},
 			{"spec", "componentName"},
+			{"spec", "build-nudges-ref", "[]"},
 		},
 		templateAbleFields: [][]string{
 			{"spec", "source", "git", "context"},

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -203,18 +203,7 @@ func applyResourceTemplate(
 	templateVarValues map[string]string,
 ) error {
 	for _, path := range templateAbleFields {
-		valueTemplate, ok, err := unstructured.NestedString(resource.Object, path...)
-		if err != nil {
-			return fmt.Errorf("error reading resource template: %s", err)
-		}
-		if !ok {
-			continue
-		}
-		value, err := executeTemplate(valueTemplate, templateVarValues)
-		if err != nil {
-			return fmt.Errorf("error applying resource template: %s", err)
-		}
-		err = unstructured.SetNestedField(resource.Object, value, path...)
+		err := applyFieldTemplate(resource.Object, path, templateVarValues)
 		if err != nil {
 			return fmt.Errorf("error applying resource template: %s", err)
 		}

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -178,7 +178,7 @@ func MkResources(
 	for i, unstructuredObj := range pdst.Spec.Resources {
 		if unhandledTemplates[i] {
 			return nil, fmt.Errorf(
-				"Unsupported resource type in template: %s",
+				"unsupported resource type in template: %s",
 				unstructuredObj.GroupVersionKind(),
 			)
 		}
@@ -206,18 +206,18 @@ func applyResourceTemplate(
 	for _, path := range templateAbleFields {
 		valueTemplate, ok, err := unstructured.NestedString(resource.Object, path...)
 		if err != nil {
-			return fmt.Errorf("Error reading resource template: %s", err)
+			return fmt.Errorf("error reading resource template: %s", err)
 		}
 		if !ok {
 			continue
 		}
 		value, err := executeTemplate(valueTemplate, templateVarValues)
 		if err != nil {
-			return fmt.Errorf("Error applying resource template: %s", err)
+			return fmt.Errorf("error applying resource template: %s", err)
 		}
 		err = unstructured.SetNestedField(resource.Object, value, path...)
 		if err != nil {
-			return fmt.Errorf("Error applying resource template: %s", err)
+			return fmt.Errorf("error applying resource template: %s", err)
 		}
 	}
 	return nil
@@ -240,7 +240,7 @@ func validateResourceNameFields(
 		}
 		if !nameFieldPattern.MatchString(value) {
 			return fmt.Errorf(
-				"Invalid resource name value '%s' for resource field '%s'. "+
+				"invalid resource name value '%s' for resource field '%s'. "+
 					"Consider using the 'hyphenize' template function",
 				value,
 				strings.Join(path, "."),
@@ -272,7 +272,7 @@ func getVarValues(
 			values[variable.Name] = value
 		} else {
 			err = fmt.Errorf(
-				"Template variable '%s' is missing a value and default not defined",
+				"template variable '%s' is missing a value and default not defined",
 				variable.Name,
 			)
 			break

--- a/internal/template/resources_internal_test.go
+++ b/internal/template/resources_internal_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Resources", func() {
 
 	Describe("validateResourceNameFields", func() {
 		var res *unstructured.Unstructured
-		
+
 		BeforeEach(func() {
 			res = &unstructured.Unstructured{
 				Object: map[string]any{
@@ -120,16 +120,27 @@ var _ = Describe("Resources", func() {
 				Expect(validateResourceNameFields(res, nameFields)).To(Succeed())
 			},
 			Entry("checks string fields", [][]string{{"key1", "key1a"}}),
+			Entry("checks slice-of-strings fields", [][]string{{"key1", "key1b", "[]"}}),
 		)
-		
+
 		DescribeTable(
 			"it finds bad k8s name values in specified field paths",
 			func(nameFields [][]string) {
 				Expect(validateResourceNameFields(res, nameFields)).ToNot(Succeed())
 			},
-			Entry("checks string fields", [][]string{{"key2", "key2a"}}),
+			Entry("checks string fields", [][]string{
+				{"key2", "key2a"},
+			}),
 			Entry("can check multiple string fields", [][]string{
 				{"key1", "key1a"},
+				{"key2", "key2a"},
+			}),
+			Entry("checks slice-of-strings fields", [][]string{
+				{"key2", "key2b", "[]"},
+			}),
+			Entry("can check multiple fields of different types", [][]string{
+				{"key1", "key1a"},
+				{"key2", "key2b", "[]"},
 				{"key2", "key2a"},
 			}),
 		)

--- a/internal/template/resources_internal_test.go
+++ b/internal/template/resources_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apischema "k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/gertd/go-pluralize"
@@ -87,5 +88,50 @@ var _ = Describe("Resources", func() {
 				allAPIsWFinAccessNdedEntries,
 			)
 		})
+	})
+
+	Describe("validateResourceNameFields", func() {
+		var res *unstructured.Unstructured
+		
+		BeforeEach(func() {
+			res = &unstructured.Unstructured{
+				Object: map[string]any{
+					"key1": map[string]any{
+						"key1a": "good-name",
+						"key1b": []any{
+							"good-name1",
+							"good-name2",
+						},
+					},
+					"key2": map[string]any{
+						"key2a": "bad.name",
+						"key2b": []any{
+							"good-name1",
+							"bad.name2",
+						},
+					},
+				},
+			}
+		})
+
+		DescribeTable(
+			"it ensures good k8s name values in specified field paths",
+			func(nameFields [][]string) {
+				Expect(validateResourceNameFields(res, nameFields)).To(Succeed())
+			},
+			Entry("checks string fields", [][]string{{"key1", "key1a"}}),
+		)
+		
+		DescribeTable(
+			"it finds bad k8s name values in specified field paths",
+			func(nameFields [][]string) {
+				Expect(validateResourceNameFields(res, nameFields)).ToNot(Succeed())
+			},
+			Entry("checks string fields", [][]string{{"key2", "key2a"}}),
+			Entry("can check multiple string fields", [][]string{
+				{"key1", "key1a"},
+				{"key2", "key2a"},
+			}),
+		)
 	})
 })

--- a/internal/template/unstructured.go
+++ b/internal/template/unstructured.go
@@ -6,25 +6,80 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// A function type for applying changes to string fields. Accespts the field
+// current value as a string and returns a new value, a boolean indicating if to
+// apply the new value to the original object and an error value that should be
+// returned from the calling function if not nil
+type fieldFunc func(string) (string, bool, error)
+
 // Given a possibly nested map structure, navigate to a particular scalar value
 // using path - a list of string keys. Then treat that value as a template and
 // apply it in-place while using the provided values.
 func applyFieldTemplate(obj map[string]any, path []string, values map[string]string) error {
-	valueTemplate, ok, err := unstructured.NestedString(obj, path...)
+	return applyFieldFunc(obj, path, func(valueTemplate string) (string, bool, error) {
+		value, err := executeTemplate(valueTemplate, values)
+		return value, true, err
+	})
+}
+
+func applyFieldFunc(obj map[string]any, path []string, ff fieldFunc) error {
+	if path[len(path)-1] == "[]" {
+		return applySliceFieldFunc(obj, path[:len(path)-1], ff)
+	} else {
+		return applyPlainFieldFunc(obj, path, ff)
+	}
+}
+
+func applyPlainFieldFunc(obj map[string]any, path []string, ff fieldFunc) error {
+	existingValue, ok, err := unstructured.NestedString(obj, path...)
 	if err != nil {
-		return fmt.Errorf("error reading object template: %s", err)
+		return fmt.Errorf("error reading object: %s", err)
 	}
 	if !ok {
 		// If the path is not found in the structure, we ignore it
 		return nil
 	}
-	value, err := executeTemplate(valueTemplate, values)
+	value, set, err := ff(existingValue)
 	if err != nil {
-		return fmt.Errorf("error applying template: %s", err)
+		return err
 	}
-	err = unstructured.SetNestedField(obj, value, path...)
+	if set {
+		err = unstructured.SetNestedField(obj, value, path...)
+		if err != nil {
+			return fmt.Errorf("error updating object: %s", err)
+		}
+	}
+	return nil
+}
+
+func applySliceFieldFunc(obj map[string]any, path []string, ff fieldFunc) error {
+	exValArr, ok, err := unstructured.NestedStringSlice(obj, path...)
 	if err != nil {
-		return fmt.Errorf("error applying template: %s", err)
+		return fmt.Errorf("error reading object: %s", err)
+	}
+	if !ok {
+		// If the path is not found in the structure, we ignore it
+		return nil
+	}
+	valueArr := make([]string, len(exValArr))
+	var setAny bool
+	for i, existingValue := range exValArr {
+		value, set, err := ff(existingValue)
+		if err != nil {
+			return err
+		}
+		if set {
+			valueArr[i] = value
+		} else {
+			valueArr[i] = existingValue
+		}
+		setAny = setAny || set
+	}
+	if setAny {
+		err = unstructured.SetNestedStringSlice(obj, valueArr, path...)
+		if err != nil {
+			return fmt.Errorf("error updating object: %s", err)
+		}
 	}
 	return nil
 }

--- a/internal/template/unstructured.go
+++ b/internal/template/unstructured.go
@@ -1,0 +1,30 @@
+package template
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Given a possibly nested map structure, navigate to a particular scalar value
+// using path - a list of string keys. Then treat that value as a template and
+// apply it in-place while using the provided values.
+func applyFieldTemplate(obj map[string]any, path []string, values map[string]string) error {
+	valueTemplate, ok, err := unstructured.NestedString(obj, path...)
+	if err != nil {
+		return fmt.Errorf("error reading object template: %s", err)
+	}
+	if !ok {
+		// If the path is not found in the structure, we ignore it
+		return nil
+	}
+	value, err := executeTemplate(valueTemplate, values)
+	if err != nil {
+		return fmt.Errorf("error applying template: %s", err)
+	}
+	err = unstructured.SetNestedField(obj, value, path...)
+	if err != nil {
+		return fmt.Errorf("error applying template: %s", err)
+	}
+	return nil
+}

--- a/internal/template/unstructured_internal_test.go
+++ b/internal/template/unstructured_internal_test.go
@@ -1,0 +1,70 @@
+package template
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var someValues = map[string]string{
+	"foo": "bar",
+	"baz": "bal",
+}
+
+var _ = DescribeTable(
+	"applyFieldTemplate aplies a template in a field within a nested structure",
+	func(obj map[string]any, path []string, values map[string]string, expected map[string]any) {
+		err := applyFieldTemplate(obj, path, values)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(obj).To(Equal(expected))
+	},
+	Entry(
+		"where path defines which key to apply to",
+		map[string]any{
+			"key1": "{{.foo}}",
+			"key2": "{{.baz}}",
+		},
+		[]string{"key1"},
+		someValues,
+		map[string]any{
+			"key1": "bar",
+			"key2": "{{.baz}}",
+		},
+	),
+	Entry(
+		"where multiple path values define key recursion",
+		map[string]any{
+			"key1": map[string]any{
+				"key1a": "{{.foo}}",
+				"key1b": "{{.baz}}",
+			},
+			"key2": map[string]any{
+				"key2a": "{{.baz}}",
+			},
+		},
+		[]string{"key1", "key1b"},
+		someValues,
+		map[string]any{
+			"key1": map[string]any{
+				"key1a": "{{.foo}}",
+				"key1b": "bal",
+			},
+			"key2": map[string]any{
+				"key2a": "{{.baz}}",
+			},
+		},
+	),
+	Entry(
+		"and not-found pathes are ignored",
+		map[string]any{
+			"key1": "{{.foo}}",
+			"key2": "{{.baz}}",
+		},
+		[]string{"key3", "key3a"},
+		someValues,
+		map[string]any{
+			"key1": "{{.foo}}",
+			"key2": "{{.baz}}",
+		},
+	),
+)

--- a/internal/template/unstructured_internal_test.go
+++ b/internal/template/unstructured_internal_test.go
@@ -67,4 +67,21 @@ var _ = DescribeTable(
 			"key2": "{{.baz}}",
 		},
 	),
+	Entry(
+		"and pathes that end with [] point to lists, all members are applied",
+		map[string]any{
+			"key1": []any{
+				"{{.foo}}",
+				"{{.baz}}",
+			},
+		},
+		[]string{"key1", "[]"},
+		someValues,
+		map[string]any{
+			"key1": []any{
+				"bar",
+				"bal",
+			},
+		},
+	),
 )


### PR DESCRIPTION
Support templating the `build-nudges-ref` field for Component resources.

Supporting this field took quite a bit of refactoring because its a list-of-strings field and so far we've only supported plain-string fields. To enable this refactoring a bunch of new unit tests were added.