### PR TITLE
fix: ImageRepo spec.image.name is not a "name"

### DIFF
--- a/config/samples/projctl_v1beta1_pds_w_imagerepo_exp_results.yaml
+++ b/config/samples/projctl_v1beta1_pds_w_imagerepo_exp_results.yaml
@@ -57,5 +57,6 @@ metadata:
 spec:
   image:
     visibility: public
+    name: coolorg/cool-app-2-2-0/cool-comp1-2-2-0
   credentials:
     verify-linking: true

--- a/config/samples/projctl_v1beta1_pdst_w_imagerepo.yaml
+++ b/config/samples/projctl_v1beta1_pdst_w_imagerepo.yaml
@@ -43,5 +43,6 @@ spec:
     spec:
       image:
         visibility: public
+        name: coolorg/cool-app-{{.versionName}}/cool-comp1-{{.versionName}}
       credentials:
         verify-linking: true

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -82,6 +82,8 @@ var supportedResourceTypes = []struct {
 			{"metadata", "name"},
 			{"metadata", "labels", "appstudio.redhat.com/component"},
 			{"metadata", "labels", "appstudio.redhat.com/application"},
+		},
+		templateAbleFields: [][]string{
 			{"spec", "image", "name"},
 		},
 		ownerNameField: []string{"metadata", "labels", "appstudio.redhat.com/component"},


### PR DESCRIPTION
The `spec.image.name` field for `ImageRepository` resources was defined as a K8s "name" field but it isn't, it actually need to be able to contain slashes which are typically found in container image names.