### PR TITLE
feat(KFLUXVNGD-97): support nested lists

### DIFF
--- a/config/samples/projctl_v1beta1_pds_w_intgtstscnario_exp_results.yaml
+++ b/config/samples/projctl_v1beta1_pds_w_intgtstscnario_exp_results.yaml
@@ -85,7 +85,7 @@ spec:
       - name: url
         value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
-        value: main
+        value: v3.3.0
       - name: pathInRepo
         value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/config/samples/projctl_v1beta1_pdst_w_intgtstscnario.yaml
+++ b/config/samples/projctl_v1beta1_pdst_w_intgtstscnario.yaml
@@ -65,7 +65,7 @@ spec:
           - name: url
             value: 'https://github.com/konflux-ci/build-definitions'
           - name: revision
-            value: main
+            value: v{{.version}}
           - name: pathInRepo
             value: pipelines/enterprise-contract.yaml
         resolver: git

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -98,9 +98,12 @@ var supportedResourceTypes = []struct {
 		templateAbleNameFields: [][]string{
 			{"metadata", "name"},
 			{"spec", "application"},
-			// TODO: Somehow allow templating spec.params and spec.resolverRef.params
-			// which are arrays of name/value pairs. This would require changes to
+			// TODO: allow templating of spec.params
+			// which is an array of name/value pairs. This would require changes to
 			// applyResourceTemplate and possibly validateResourceNameFields
+		},
+		templateAbleFields: [][]string{
+			{"spec", "resolverRef", "params", "[]", "value"},
 		},
 		ownerNameField: []string{"spec", "application"},
 		ownerAPI: apischema.GroupVersionKind{

--- a/internal/template/unstructured_internal_test.go
+++ b/internal/template/unstructured_internal_test.go
@@ -11,7 +11,7 @@ var someValues = map[string]string{
 }
 
 var _ = DescribeTable(
-	"applyFieldTemplate aplies a template in a field within a nested structure",
+	"applyFieldTemplate applies a template in a field within a nested structure",
 	func(obj map[string]any, path []string, values map[string]string, expected map[string]any) {
 		err := applyFieldTemplate(obj, path, values)
 
@@ -68,7 +68,7 @@ var _ = DescribeTable(
 		},
 	),
 	Entry(
-		"and pathes that end with [] point to lists, all members are applied",
+		"and paths that end with [] point to lists, all members are applied",
 		map[string]any{
 			"key1": []any{
 				"{{.foo}}",
@@ -82,6 +82,117 @@ var _ = DescribeTable(
 				"bar",
 				"bal",
 			},
+		},
+	),
+	Entry(
+		"and paths that contain [] point to lists of non-scalar values",
+		map[string]any{
+			"key1": []any{
+				map[string]any{
+					"key1a": "{{.foo}}",
+					"key1b": "{{.baz}}",
+				},
+				map[string]any{
+					"key1a": "{{.foo}}",
+					"key1b": "{{.baz}}",
+				},
+				map[string]any{
+					"key1c": "{{.foo}}",
+					"key1d": "{{.baz}}",
+				},
+			},
+		},
+		[]string{"key1", "[]", "key1b"},
+		someValues,
+		map[string]any{
+			"key1": []any{
+				map[string]any{
+					"key1a": "{{.foo}}",
+					"key1b": "bal",
+				},
+				map[string]any{
+					"key1a": "{{.foo}}",
+					"key1b": "bal",
+				},
+				map[string]any{
+					"key1c": "{{.foo}}",
+					"key1d": "{{.baz}}",
+				},
+			},
+		},
+	),
+	Entry(
+		"and paths may contain [] multiple times",
+		map[string]any{
+			"key1": []any{
+				map[string]any{
+					"key1a": "{{.foo}}",
+					"key1b": []any{
+						map[string]any{
+							"key1a":  "{{.foo}}",
+							"key1b1": "{{.baz}}",
+						},
+					},
+				},
+				map[string]any{
+					"key1a": "{{.foo}}",
+					"key1b": "{{.baz}}",
+				},
+				map[string]any{
+					"key1c": "{{.foo}}",
+					"key1d": "{{.baz}}",
+				},
+			},
+		},
+		[]string{"key1", "[]", "key1b", "[]", "key1b1"},
+		someValues,
+		map[string]any{
+			"key1": []any{
+				map[string]any{
+					"key1a": "{{.foo}}",
+					"key1b": []any{
+						map[string]any{
+							"key1a":  "{{.foo}}",
+							"key1b1": "bal",
+						},
+					},
+				},
+				map[string]any{
+					"key1a": "{{.foo}}",
+					"key1b": "{{.baz}}",
+				},
+				map[string]any{
+					"key1c": "{{.foo}}",
+					"key1d": "{{.baz}}",
+				},
+			},
+		},
+	),
+	Entry(
+		"and paths that end with [] can be nested inside other lists",
+		map[string]any{
+			"key1": []any{
+				map[string]any{
+					"key1a": []any{
+						"{{.foo}}",
+						"{{.baz}}",
+					},
+				},
+			},
+			"key2": "{{.baz}}",
+		},
+		[]string{"key1", "[]", "key1a", "[]"},
+		someValues,
+		map[string]any{
+			"key1": []any{
+				map[string]any{
+					"key1a": []any{
+						"bar",
+						"bal",
+					},
+				},
+			},
+			"key2": "{{.baz}}",
 		},
 	),
 )


### PR DESCRIPTION
We'd like to templatize IntegrationTestScenario's resolverRef field. This field contains a list of key-value pairs, and for that we need to support lists in arbitrary levels of the template (not only leaf-level).