### PR TITLE
fix(KFLUXVNGD-45): RBAC and over-logging to events

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -71,6 +71,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - projctl.konflux.dev
   resources:
   - projectdevelopmentstreams

--- a/internal/controller/projectdevelopmentstream_controller.go
+++ b/internal/controller/projectdevelopmentstream_controller.go
@@ -51,6 +51,8 @@ type ProjectDevelopmentStreamReconciler struct {
 //+kubebuilder:rbac:groups=projctl.konflux.dev,resources=projects,verbs=get;list;watch
 //+kubebuilder:rbac:groups=projctl.konflux.dev,resources=projectdevelopmentstreamtemplates,verbs=get;list;watch
 
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // TODO(user): Modify the Reconcile function to compare the state specified by

--- a/internal/controller/projectdevelopmentstream_controller_test.go
+++ b/internal/controller/projectdevelopmentstream_controller_test.go
@@ -65,7 +65,7 @@ var _ = Describe("ProjectDevelopmentStream Controller", func() {
 				controllerReconciler := &ProjectDevelopmentStreamReconciler{
 					Client:   saClient,
 					Scheme:   saClient.Scheme(),
-					Recorder: k8sCluster.GetEventRecorderFor("ProjectDevelopmentStream-controller-tests"),
+					Recorder: saCluster.GetEventRecorderFor("ProjectDevelopmentStream-controller-tests"),
 				}
 
 				By("Setting the owner reference")

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -56,8 +56,8 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var saClient client.Client
+var saCluster cluster.Cluster
 var testEnv *envtest.Environment
-var k8sCluster cluster.Cluster
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -128,9 +128,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(saClient).NotTo(BeNil())
 
-	k8sCluster, err = cluster.New(cfg)
+	saCluster, err = cluster.New(saCfg)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sCluster).NotTo(BeNil())
+	Expect(saCluster).NotTo(BeNil())
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Fixed a couple of issues with logging to PDS events:

1. We were not setting up the right RBAC permissions to create Events
2. We were logging level 1 and above logs to events though we shouldn't