### PR TITLE
fix(KFLUXVNGD-167): lint errors

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -75,6 +75,7 @@ spec:
         image: controller:latest
         name: manager
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:


### PR DESCRIPTION
infra-deployments PR fails as the container was missing readOnlyRootFilesystem in security context.