### PR TITLE
Add params value of Integration Tests to templateAbleFields list

### DIFF
--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -104,6 +104,7 @@ var supportedResourceTypes = []struct {
 			// applyResourceTemplate and possibly validateResourceNameFields
 		},
 		templateAbleFields: [][]string{
+			{"spec", "params", "[]", "value"},
 			{"spec", "resolverRef", "params", "[]", "value"},
 			{"spec", "contexts", "[]", "name"},
 			{"spec", "contexts", "[]", "description"},


### PR DESCRIPTION
This PR allows to use templates in `spec.params.[].values` fields for Integration Tests.

Example:
```
      apiVersion: appstudio.redhat.com/v1beta2
      kind: IntegrationTestScenario
      metadata:
        labels:
          test.appstudio.openshift.io/optional: "true"
        name: ossm-fbc-{{ .versionName }}-deploy-operator
        namespace: service-mesh-tenant
      spec:
        application: ossm-fbc-{{ .versionName }}
        contexts:
          - description: Deploy operator testing for ossm-fbc-{{ .versionName }}
            name: disabled
        params:
          - name: PACKAGE_NAME
            value: servicemeshoperator3
          - name: CHANNEL_NAME
            value: stable
          - name: CREDENTIALS_SECRET_NAME
            value: ossm-fbc-{{ .versionName }}-deploy-operator
          - name: OCI_REF
            value: quay.io/redhat-user-workloads/service-mesh-tenant/ossm-fbc-{{ .versionName }}
        resolverRef:
          params:
            - name: url
              value: https://github.com/konflux-ci/tekton-integration-catalog.git
            - name: revision
              value: main
            - name: pathInRepo
              value: pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
          resolver: git
```