### PR TITLE
chore: remove concurrent PR limit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "prConcurrentLimit": 0
+}


### PR DESCRIPTION
We have issues with some go-related PRs and while those are open new ones are not being created. Removing the limit on concurrent PRs so we keep get updates until we address the issue.