### PR TITLE
Add RP.spec.data.releaseNotes.references into templateable fields

### DIFF
--- a/config/samples/projctl_v1beta1_pds_w_relpln_exp_results.yaml
+++ b/config/samples/projctl_v1beta1_pds_w_relpln_exp_results.yaml
@@ -109,3 +109,8 @@ spec:
   application: "cool-app-4-4-0"
   releaseGracePeriodDays: 7
   target: cool-app-releng-tenant
+  data:
+    releaseNotes:
+      description: "Description"
+      references:
+        - "reference 4.4.0"

--- a/config/samples/projctl_v1beta1_pdst_w_relpln.yaml
+++ b/config/samples/projctl_v1beta1_pdst_w_relpln.yaml
@@ -89,3 +89,8 @@ spec:
       application: "cool-app-{{.versionName}}"
       releaseGracePeriodDays: 7
       target: cool-app-releng-tenant
+      data:
+        releaseNotes:
+          description: "Description"
+          references:
+            - "reference {{.version}}"

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -125,6 +125,9 @@ var supportedResourceTypes = []struct {
 			{"metadata", "labels", "release.appstudio.openshift.io/releasePlanAdmission"},
 			{"spec", "application"},
 		},
+		templateAbleFields: [][]string{
+			{"spec", "data", "releaseNotes", "references", "[]"},
+		},
 		ownerNameField: []string{"spec", "application"},
 		ownerAPI: apischema.GroupVersionKind{
 			Group: "appstudio.redhat.com", Version: "v1alpha1", Kind: "Application",


### PR DESCRIPTION
We (RHTAP) want to use templates in ReleasePlan spec.data.releaseNotes.references.