### PR TITLE
git-provider and  git-provider-url as templateAbleFields

### DIFF
--- a/config/samples/projctl_v1beta1_pds_w_tmp_vars_exp_results.yaml
+++ b/config/samples/projctl_v1beta1_pds_w_tmp_vars_exp_results.yaml
@@ -41,6 +41,8 @@ metadata:
   name: "cool-comp1-1-0-0"
   annotations:
     pvc.konflux.dev/cloned-from: cool_comp1_main
+    git-provider: github
+    git-provider-url: https://github.com
     mintmaker.appstudio.redhat.com/disabled: "false"
   ownerReferences:
   - apiVersion: "appstudio.redhat.com/v1alpha1"

--- a/config/samples/projctl_v1beta1_projectdevelopmentstreamtemplate.yaml
+++ b/config/samples/projctl_v1beta1_projectdevelopmentstreamtemplate.yaml
@@ -36,6 +36,12 @@ spec:
   - name: cool_comp2_revision
     defaultValue: fixed-rev
     description: Git revision for cool-comp2 component
+  - name: cool_git_provider
+    defaultValue: github
+    description: Source Git provider
+  - name: cool_git_provider_url
+    defaultValue: https://github.com
+    description: Source Git provider url
 
   - name: mintmaker_disable
     defaultValue: "true"
@@ -57,6 +63,8 @@ spec:
       name: "cool-comp1-{{.versionName}}"
       annotations:
         pvc.konflux.dev/cloned-from: cool_comp1_main
+        git-provider: "{{.cool_git_provider}}"
+        git-provider-url: "{{.cool_git_provider_url}}"
         mintmaker.appstudio.redhat.com/disabled: "{{.mintmaker_disable}}"
     spec:
       application: "cool-app-{{.versionName}}"

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -69,6 +69,8 @@ var supportedResourceTypes = []struct {
 			{"spec", "source", "git", "dockerfileUrl"},
 			{"spec", "source", "git", "revision"},
 			{"spec", "source", "git", "url"},
+			{"metadata", "annotations", "git-provider"},
+			{"metadata", "annotations", "git-provider-url"},
 		},
 		ownerNameField: []string{"spec", "application"},
 		ownerAPI: apischema.GroupVersionKind{


### PR DESCRIPTION
Ansible team is starting a migration process where basically different Ansible versions (aap-2.5, aap-2.4) will be migrated from GitLab to GitHub. In an intermediate state of the migration, we'll have different versions on different git providers. Not having dynamic variables for git-provider and git-provider-url means creating more projects. We would like to keep every component (as of today we have 21 components) stick to a single Project.