### PR TITLE
fix(KFLUXVNGD-459): Remove leader election since replicas == 1

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /manager
         args:
-        - --leader-elect
+        - --leader-elect=false
         - --health-probe-bind-address=:8081
         - --metrics-secure=true
         image: controller:latest


### PR DESCRIPTION
This change will disable leader election, which is inefficient and makes the service more sensitive to API server load.