### PR TITLE
fix(KFLUXVNGF-433): Avoid configure-pac loops

### DIFF
--- a/config/samples/appstudio_v1alpha1_comp.yaml
+++ b/config/samples/appstudio_v1alpha1_comp.yaml
@@ -3,7 +3,8 @@ kind: Component
 metadata:
   name: "cool-comp1-5-5-0"
   annotations:
-    applicationFailCounter: "5"  
+    applicationFailCounter: "5"
+    appstudio.openshift.io/request: "deploy"
   finalizers:
     - test.appstudio.openshift.io/component
     - image-controller.appstudio.openshift.io/image-repository

--- a/config/samples/projctl_v1beta1_pds_w_existing_comp_exp_results.yaml
+++ b/config/samples/projctl_v1beta1_pds_w_existing_comp_exp_results.yaml
@@ -18,7 +18,8 @@ metadata:
     kind: "Application"
     name: "cool-app-5-5-0"
   annotations:
-    applicationFailCounter: "0"    
+    applicationFailCounter: "0"
+    appstudio.openshift.io/request: "deploy"
   finalizers:
     - test.appstudio.openshift.io/component
     - image-controller.appstudio.openshift.io/image-repository

--- a/config/samples/projctl_v1beta1_pdst_w_existing_comp.yaml
+++ b/config/samples/projctl_v1beta1_pdst_w_existing_comp.yaml
@@ -24,7 +24,8 @@ spec:
     metadata:
       name: "cool-comp1-{{.versionName}}"
       annotations:
-        applicationFailCounter: "0"      
+        applicationFailCounter: "0"
+        appstudio.openshift.io/request: "configure-pac"
     spec:
       application: "cool-app-{{.versionName}}"
       componentName: "cool-comp1-{{.versionName}}"

--- a/config/samples/projctl_v1beta1_projectdevelopmentstreamtemplate.yaml
+++ b/config/samples/projctl_v1beta1_projectdevelopmentstreamtemplate.yaml
@@ -66,6 +66,7 @@ spec:
         git-provider: "{{.cool_git_provider}}"
         git-provider-url: "{{.cool_git_provider_url}}"
         mintmaker.appstudio.redhat.com/disabled: "{{.mintmaker_disable}}"
+        appstudio.openshift.io/request: "configure-pac"
     spec:
       application: "cool-app-{{.versionName}}"
       componentName: "cool-comp1-{{.versionName}}"
@@ -85,6 +86,7 @@ spec:
       name: "cool-comp2-{{.versionName}}"
       annotations:
         pvc.konflux.dev/cloned-from: cool_comp2_main
+        appstudio.openshift.io/request: "configure-pac"
     spec:
       application: "cool-app-{{.versionName}}"
       componentName: "cool-comp2-{{.versionName}}"


### PR DESCRIPTION
"configure-pac loops" happen when the `appstudio.openshift.io/request`
annotation is set to `configure-pac` in a `Component` resource in a
`ProjectDevelopmentStreamTemplate`. When this is the case the
controller is settilg the annotation value on the component when it
reconciles, but that causes the build service to perform PAC
configuration including the creation of pipeline configuration PRs and
then remove the label. Following that, the project-controller
recreates the label on the next reconcillation, which causes the build
service to run configuration again and on and on...

The solution for this is to define a list of `untouchableFields` that
are simply ignored when specified in a template and are never set or
updated by the project-controller.
