### PR TITLE
Remove grouping of tekton bundle dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,7 @@
       ]
     },
     {
-      "description": "Group Tekton bundle updates together",
-      "groupName": "tekton-bundles",
+      "description": "Auto-merge Tekton bundle updates",
       "automerge": true,
       "autoApprove": true,
       "matchPackageNames": [


### PR DESCRIPTION
These are already grouped by the default mintmaker config. It's suspected that this additional group is causing conflicts because there are two branch topics trying to update the same dependencies.