### PR TITLE
fix(KONFLUX-13484): add spec.containerImage to Component templateAbleFields

### DIFF
--- a/config/samples/projctl_v1beta1_pds_w_tmp_vars_exp_results.yaml
+++ b/config/samples/projctl_v1beta1_pds_w_tmp_vars_exp_results.yaml
@@ -60,6 +60,7 @@ metadata:
 spec:
   application: "cool-app-1-0-0"
   componentName: "cool-comp1-1-0-0"
+  containerImage: "quay.io/redhat-user-workloads/test-tenant/cool-comp1-1-0-0"
   source:
     git:
       context: "./"

--- a/config/samples/projctl_v1beta1_projectdevelopmentstreamtemplate.yaml
+++ b/config/samples/projctl_v1beta1_projectdevelopmentstreamtemplate.yaml
@@ -71,6 +71,7 @@ spec:
     spec:
       application: "cool-app-{{.versionName}}"
       componentName: "cool-comp1-{{.versionName}}"
+      containerImage: "quay.io/redhat-user-workloads/test-tenant/cool-comp1-{{.versionName}}"
       source:
         git:
           context: "{{.cool_comp1_context}}"

--- a/internal/template/execute_internal_test.go
+++ b/internal/template/execute_internal_test.go
@@ -24,4 +24,10 @@ var _ = DescribeTable(
 		map[string]string{"version": "1.2.3"},
 		"1-2-3",
 	),
+	Entry(
+		"with newline inside delimiters (as produced by YAML line wrapping after parsing)",
+		"quay.io/tenant/comp-{{\n      .versionName }}:tag",
+		map[string]string{"versionName": "4-22"},
+		"quay.io/tenant/comp-4-22:tag",
+	),
 )

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -70,6 +70,7 @@ var supportedResourceTypes = []struct {
 			{"metadata", "annotations", "mintmaker.appstudio.redhat.com/disabled"},
 		},
 		templateAbleFields: [][]string{
+			{"spec", "containerImage"},
 			{"spec", "source", "git", "context"},
 			{"spec", "source", "git", "dockerfileUrl"},
 			{"spec", "source", "git", "revision"},


### PR DESCRIPTION
The build-service reads spec.containerImage from Component resources to construct the output-image parameter in .tekton PipelineRun files. When a ProjectDevelopmentStreamTemplate defines containerImage with template variables (e.g. {{ .versionName }}), the project-controller was not substituting them because containerImage was missing from the templateAbleFields list, causing literal template expressions to appear in generated .tekton PRs.

Jira-Url: https://redhat.atlassian.net/browse/KONFLUX-13484
Assisted-by: Claude Code