### PR TITLE
docs: add AGENTS.md with agent guidance and CI line-limit check

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -23,5 +23,12 @@ jobs:
       with:
         go-version-file: go.mod
 
+    - name: Check AGENTS.md line limit
+      run: |
+        MAX_LINES=60
+        LINES=$(grep -c '' AGENTS.md)
+        echo "AGENTS.md has $LINES lines (limit: $MAX_LINES)"
+        [ "$LINES" -lt "$MAX_LINES" ] || { echo "AGENTS.md must be under $MAX_LINES lines"; exit 1; }
+
     - name: Run Lint
       run: make lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# Agent Guidelines for project-controller
+
+## Project Overview
+
+Kubernetes controller (kubebuilder v4) for Konflux CI. Three CRDs in `projctl.konflux.dev/v1beta1`:
+- **Project** — groups development streams
+- **ProjectDevelopmentStreamTemplate** — Go `text/template`-based resource generator
+- **ProjectDevelopmentStream (PDS)** — the only reconciled CRD; creates resources via server-side apply
+
+Only PDS has a reconciler. Changes to Project or Template trigger PDS re-reconciliation.
+
+## Build & Test
+
+```bash
+make build          # binary → bin/manager
+make test           # unit tests (envtest), also runs fmt/vet/generate
+make lint           # golangci-lint
+make lint-fix       # golangci-lint with --fix
+make manifests      # regenerate CRDs + RBAC after changing kubebuilder markers
+make generate       # regenerate deepcopy after changing api/v1beta1/ types
+```
+
+## Key Files
+
+| Purpose | Path |
+|---------|------|
+| PDS reconciler | `internal/controller/projectdevelopmentstream_controller.go` |
+| Resource type registry | `internal/template/resources.go` — `supportedResourceTypes` table |
+| Template execution | `internal/template/execute.go` |
+| Owner ref handling | `internal/ownership/` |
+| CRD type definitions | `api/v1beta1/` |
+| Test fixtures | `config/samples/` (inputs + `*_exp_results.yaml` expected outputs) |
+
+## Adding a New Template-Supported Resource Type
+
+1. Add entry to `supportedResourceTypes` in `internal/template/resources.go`
+2. Add `//+kubebuilder:rbac` markers in the same file
+3. Import the API in `internal/controller/suite_test.go` for CRD loading in tests
+4. Run `make manifests` to regenerate RBAC and CRDs
+5. Add test fixtures in `config/samples/`
+
+## Reconciliation Flow
+
+`ProjectDevelopmentStreamReconciler.Reconcile` in the controller file:
+1. Sets Project as owner of PDS (re-queues after update)
+2. If no template ref, marks Ready=True/NoTemplate and returns
+3. Fetches referenced template, calls `template.MkResources()`
+4. Server-side applies each resource (field owner: `projctl.konflux.dev`)
+5. Sets Ready condition on PDS status
+
+## Rules
+
+- Always run `make test` before submitting — it includes fmt, vet, generate, and manifests
+- RBAC markers live in two places: `internal/controller/` and `internal/template/resources.go`
+- Run `make manifests` after any RBAC marker change
+- Tests use Ginkgo/Gomega with envtest, impersonating `system:serviceaccount:system:controller-manager`
+- The custom `hyphenize` template function is available in template specs


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` (57 lines) — a concise, agent-agnostic reference covering project overview, build commands, key files, common modification tasks, reconciliation flow, and coding rules
- Enforce the 60-line limit via a new step in the existing `go-lint` CI workflow using `grep -c ''` for accurate line counting regardless of trailing newline

## Testing

**Test Environment:** Claude Code (Claude Opus 4.6)

**Methodology:** Ran the same investigative task ("figure out what files need changing to add a new template-supported resource type") with two agents in parallel — one with AGENTS.md context and one without.

**Task:** "A user reports that when they add a new resource type to the template system, the controller doesn't have RBAC permissions to create it. Figure out what files need to be changed and in what order."

### Results

| Metric | Without AGENTS.md | With AGENTS.md |
|--------|-------------------|----------------|
| Tool calls | 4 | 3 |
| Tokens consumed | 19,127 | 15,055 |
| Duration | 21.7s | 19.5s |
| Correct answer | Yes | Yes |
| Complete answer | Yes | Yes |

**Key qualitative difference:** The agent with AGENTS.md started with the correct mental model and used tool calls purely for verification, while the agent without AGENTS.md spent its calls on discovery (reading the Makefile and generated RBAC output to understand the regeneration pipeline). The efficiency gap would widen on more complex tasks requiring understanding of the reconciliation flow, testing conventions, or the split RBAC marker pattern.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-970
Co-Authored-By: Claude Opus 4.6