### PR TITLE
fix(KONFLUX-14271): prevent early ImageRepository annotation removal

### DIFF
--- a/config/samples/projctl_v1beta1_pds_w_imagerepo_exp_results.yaml
+++ b/config/samples/projctl_v1beta1_pds_w_imagerepo_exp_results.yaml
@@ -58,6 +58,8 @@ metadata:
   labels:
     appstudio.redhat.com/component: "cool-comp1-2-2-0"
     appstudio.redhat.com/application: "cool-app-2-2-0"
+  annotations:
+    image-controller.appstudio.redhat.com/update-component-image: "true"
   ownerReferences:
   - apiVersion: "appstudio.redhat.com/v1alpha1"
     kind: "Component"

--- a/config/samples/projctl_v1beta1_pds_w_intgtstscnario_exp_results.yaml
+++ b/config/samples/projctl_v1beta1_pds_w_intgtstscnario_exp_results.yaml
@@ -58,6 +58,8 @@ metadata:
   labels:
     appstudio.redhat.com/component: "cool-comp1-3-3-0"
     appstudio.redhat.com/application: "cool-app-3-3-0"
+  annotations:
+    image-controller.appstudio.redhat.com/update-component-image: "true"
   ownerReferences:
   - apiVersion: "appstudio.redhat.com/v1alpha1"
     kind: "Component"

--- a/config/samples/projctl_v1beta1_pds_w_relpln_exp_results.yaml
+++ b/config/samples/projctl_v1beta1_pds_w_relpln_exp_results.yaml
@@ -58,6 +58,8 @@ metadata:
   labels:
     appstudio.redhat.com/component: "cool-comp1-4-4-0"
     appstudio.redhat.com/application: "cool-app-4-4-0"
+  annotations:
+    image-controller.appstudio.redhat.com/update-component-image: "true"
   ownerReferences:
   - apiVersion: "appstudio.redhat.com/v1alpha1"
     kind: "Component"

--- a/config/samples/projctl_v1beta1_pdst_w_imagerepo.yaml
+++ b/config/samples/projctl_v1beta1_pdst_w_imagerepo.yaml
@@ -40,6 +40,8 @@ spec:
       labels:
         appstudio.redhat.com/component: "cool-comp1-{{.versionName}}"
         appstudio.redhat.com/application: "cool-app-{{.versionName}}"
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: "true"
     spec:
       image:
         visibility: public

--- a/config/samples/projctl_v1beta1_pdst_w_intgtstscnario.yaml
+++ b/config/samples/projctl_v1beta1_pdst_w_intgtstscnario.yaml
@@ -40,6 +40,8 @@ spec:
       labels:
         appstudio.redhat.com/component: "cool-comp1-{{.versionName}}"
         appstudio.redhat.com/application: "cool-app-{{.versionName}}"
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: "true"
     spec:
       image:
         visibility: public

--- a/config/samples/projctl_v1beta1_pdst_w_relpln.yaml
+++ b/config/samples/projctl_v1beta1_pdst_w_relpln.yaml
@@ -40,6 +40,8 @@ spec:
       labels:
         appstudio.redhat.com/component: "cool-comp1-{{.versionName}}"
         appstudio.redhat.com/application: "cool-app-{{.versionName}}"
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: "true"
     spec:
       image:
         visibility: public

--- a/internal/controller/projectdevelopmentstream_controller.go
+++ b/internal/controller/projectdevelopmentstream_controller.go
@@ -43,6 +43,8 @@ import (
 const (
 	// ConditionTypeReady represents the Ready condition type
 	ConditionTypeReady = "Ready"
+	// ImageControllerUpdateAnnotation is the annotation that signals image-controller to update Component.spec.containerImage
+	ImageControllerUpdateAnnotation = "image-controller.appstudio.redhat.com/update-component-image"
 )
 
 // ProjectDevelopmentStreamReconciler reconciles a ProjectDevelopmentStream object
@@ -161,17 +163,55 @@ func (r *ProjectDevelopmentStreamReconciler) Reconcile(ctx context.Context, req 
 // conflict for the resource and therefore the reconcile action should be
 // re-queued.
 func (r *ProjectDevelopmentStreamReconciler) createOrUpdateResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) bool {
-	if template.HasCreateOnlyFields(resource) {
-		exists, err := r.resourceExists(ctx, resource)
-		if err != nil {
-			logger.Error(err, "Failed to check if resource exists", "name", resource.GetName(), "kind", resource.GetKind())
-			return true
-		}
-		if exists {
-			template.RemoveCreateOnlyFields(resource)
-		}
+	// Check if resource exists and remove createOnlyFields if it does
+	exists, err := r.resourceExists(ctx, resource)
+	if err != nil {
+		logger.Error(err, "Failed to check if resource exists", "name", resource.GetName(), "kind", resource.GetKind())
+		return true
 	}
-	err := r.Patch(
+
+	if exists && template.HasCreateOnlyFields(resource) {
+		template.RemoveCreateOnlyFields(resource)
+	}
+
+	// Special handling for ImageRepository: check if the live resource has the annotation.
+	// If the ImageRepository exists and doesn't have the annotation, don't re-apply it
+	// (image-controller already processed it). This prevents reconciliation churn.
+	if resource.GetKind() == "ImageRepository" && resource.GetAPIVersion() == "appstudio.redhat.com/v1alpha1" && exists {
+		// Get the live ImageRepository to check its current state
+		liveImageRepo := &unstructured.Unstructured{}
+		liveImageRepo.SetAPIVersion(resource.GetAPIVersion())
+		liveImageRepo.SetKind(resource.GetKind())
+
+		err := r.Get(ctx, client.ObjectKey{
+			Namespace: resource.GetNamespace(),
+			Name:      resource.GetName(),
+		}, liveImageRepo)
+
+		if err == nil {
+			liveAnnotations := liveImageRepo.GetAnnotations()
+
+			// If the live resource doesn't have the annotation, remove it from our desired state
+			// (image-controller has already processed this ImageRepository)
+			if liveAnnotations == nil || liveAnnotations[ImageControllerUpdateAnnotation] == "" {
+				annotations := resource.GetAnnotations()
+				if annotations != nil {
+					delete(annotations, ImageControllerUpdateAnnotation)
+					if len(annotations) == 0 {
+						resource.SetAnnotations(nil)
+					} else {
+						resource.SetAnnotations(annotations)
+					}
+					logger.V(1).Info("Skipping image-controller annotation (already processed by image-controller)",
+						"ImageRepository", resource.GetName())
+				}
+			}
+		}
+		// If we can't get the live resource, proceed with applying as-is (shouldn't happen since exists=true)
+	}
+
+	// Apply the resource using Server-Side Apply with ForceOwnership.
+	err = r.Patch(
 		ctx,
 		resource,
 		client.Apply, //nolint:staticcheck // deprecated: will be migrated to new Apply API in future

--- a/internal/controller/projectdevelopmentstream_controller.go
+++ b/internal/controller/projectdevelopmentstream_controller.go
@@ -163,55 +163,69 @@ func (r *ProjectDevelopmentStreamReconciler) Reconcile(ctx context.Context, req 
 // conflict for the resource and therefore the reconcile action should be
 // re-queued.
 func (r *ProjectDevelopmentStreamReconciler) createOrUpdateResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) bool {
-	// Check if resource exists and remove createOnlyFields if it does
-	exists, err := r.resourceExists(ctx, resource)
-	if err != nil {
-		logger.Error(err, "Failed to check if resource exists", "name", resource.GetName(), "kind", resource.GetKind())
-		return true
+	// Only check if resource exists if we need to handle createOnlyFields or liveStateConditionalFields
+	needsExistenceCheck := template.HasCreateOnlyFields(resource) ||
+		len(template.GetLiveStateConditionalFields(resource)) > 0
+
+	var exists bool
+	if needsExistenceCheck {
+		var err error
+		exists, err = r.resourceExists(ctx, resource)
+		if err != nil {
+			logger.Error(err, "Failed to check if resource exists", "name", resource.GetName(), "kind", resource.GetKind())
+			return true
+		}
 	}
 
 	if exists && template.HasCreateOnlyFields(resource) {
 		template.RemoveCreateOnlyFields(resource)
 	}
 
-	// Special handling for ImageRepository: check if the live resource has the annotation.
-	// If the ImageRepository exists and doesn't have the annotation, don't re-apply it
-	// (image-controller already processed it). This prevents reconciliation churn.
-	if resource.GetKind() == "ImageRepository" && resource.GetAPIVersion() == "appstudio.redhat.com/v1alpha1" && exists {
-		// Get the live ImageRepository to check its current state
-		liveImageRepo := &unstructured.Unstructured{}
-		liveImageRepo.SetAPIVersion(resource.GetAPIVersion())
-		liveImageRepo.SetKind(resource.GetKind())
+	// Handle live-state conditional fields: fields that should only be included in the desired state
+	// if they exist in the live resource. This is used for fields that signal one-time processing
+	// by another controller (e.g., annotations that are removed after processing).
+	if exists {
+		conditionalFields := template.GetLiveStateConditionalFields(resource)
+		if len(conditionalFields) > 0 {
+			// Get the live resource to check its current state
+			liveResource := &unstructured.Unstructured{}
+			liveResource.SetAPIVersion(resource.GetAPIVersion())
+			liveResource.SetKind(resource.GetKind())
 
-		err := r.Get(ctx, client.ObjectKey{
-			Namespace: resource.GetNamespace(),
-			Name:      resource.GetName(),
-		}, liveImageRepo)
+			err := r.Get(ctx, client.ObjectKey{
+				Namespace: resource.GetNamespace(),
+				Name:      resource.GetName(),
+			}, liveResource)
 
-		if err == nil {
-			liveAnnotations := liveImageRepo.GetAnnotations()
-
-			// If the live resource doesn't have the annotation, remove it from our desired state
-			// (image-controller has already processed this ImageRepository)
-			if liveAnnotations == nil || liveAnnotations[ImageControllerUpdateAnnotation] == "" {
-				annotations := resource.GetAnnotations()
-				if annotations != nil {
-					delete(annotations, ImageControllerUpdateAnnotation)
-					if len(annotations) == 0 {
-						resource.SetAnnotations(nil)
-					} else {
-						resource.SetAnnotations(annotations)
+			if err == nil {
+				// For each conditional field, check if it exists in the live resource
+				for _, fieldPath := range conditionalFields {
+					value, existsInLive, _ := unstructured.NestedFieldNoCopy(liveResource.Object, fieldPath...)
+					// Remove field if it doesn't exist OR if it's an empty string
+					// (matching original behavior for annotations that may be set to "")
+					if !existsInLive || (value != nil && value == "") {
+						// Field doesn't exist or is empty in live resource, remove it from desired state
+						unstructured.RemoveNestedField(resource.Object, fieldPath...)
+						logger.V(1).Info("Removing live-state conditional field (not present or empty in live resource)",
+							"kind", resource.GetKind(), "name", resource.GetName(), "field", fieldPath)
 					}
-					logger.V(1).Info("Skipping image-controller annotation (already processed by image-controller)",
-						"ImageRepository", resource.GetName())
+				}
+
+				// Clean up empty annotation maps if all annotations were removed
+				// This matches the original behavior and keeps resources clean
+				if len(conditionalFields) > 0 {
+					annotations := resource.GetAnnotations()
+					if annotations != nil && len(annotations) == 0 {
+						resource.SetAnnotations(nil)
+					}
 				}
 			}
+			// If we can't get the live resource, proceed with applying as-is (shouldn't happen since exists=true)
 		}
-		// If we can't get the live resource, proceed with applying as-is (shouldn't happen since exists=true)
 	}
 
 	// Apply the resource using Server-Side Apply with ForceOwnership.
-	err = r.Patch(
+	err := r.Patch(
 		ctx,
 		resource,
 		client.Apply, //nolint:staticcheck // deprecated: will be migrated to new Apply API in future

--- a/internal/controller/projectdevelopmentstream_controller_test.go
+++ b/internal/controller/projectdevelopmentstream_controller_test.go
@@ -296,3 +296,179 @@ func dropTimestamps(obj *unstructured.Unstructured) {
 func keepNamespaces() bool {
 	return strings.ToLower(os.Getenv("KEEP_TEST_NAMESPACES")) == "true"
 }
+
+var _ = Describe("ImageRepository annotation persistence", func() {
+	Context("When reconciling a PDS with ImageRepository", func() {
+		var (
+			ctx        context.Context
+			testNs     string
+			testNsN    types.NamespacedName
+			reconciler *ProjectDevelopmentStreamReconciler
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			testNs = setupTestNamespace(ctx, k8sClient)
+			testNsN = types.NamespacedName{
+				Namespace: testNs,
+				Name:      "pds-sample-w-imagerepo",
+			}
+
+			// Apply test resources
+			applySampleFile(ctx, k8sClient, "projctl_v1beta1_project.yaml", testNs)
+			applySampleFile(ctx, k8sClient, "projctl_v1beta1_pdst_w_imagerepo.yaml", testNs)
+			applySampleFile(ctx, k8sClient, "projctl_v1beta1_pds_w_imagerepo.yaml", testNs)
+
+			reconciler = &ProjectDevelopmentStreamReconciler{
+				Client:   saClient,
+				Scheme:   saClient.Scheme(),
+				Recorder: saCluster.GetEventRecorder("ProjectDevelopmentStream-controller-tests"),
+			}
+		})
+
+		It("should preserve image-controller annotation across reconciliations", func() {
+			// First reconcile: Set owner reference
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Second reconcile: Create resources including ImageRepository with annotation
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify ImageRepository was created with the annotation
+			imageRepoName := types.NamespacedName{
+				Namespace: testNs,
+				Name:      "cool-comp1-repo-2-2-0",
+			}
+			imageRepo := &unstructured.Unstructured{}
+			imageRepo.SetAPIVersion("appstudio.redhat.com/v1alpha1")
+			imageRepo.SetKind("ImageRepository")
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+
+			// The annotation should be present after initial creation
+			annotations := imageRepo.GetAnnotations()
+			Expect(annotations).NotTo(BeNil())
+			Expect(annotations).To(HaveKey(ImageControllerUpdateAnnotation))
+			Expect(annotations[ImageControllerUpdateAnnotation]).To(Equal("true"))
+
+			// Third reconcile: Should preserve the annotation (live resource has it)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the annotation is still present
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+			annotations = imageRepo.GetAnnotations()
+			Expect(annotations).NotTo(BeNil())
+			Expect(annotations).To(HaveKey(ImageControllerUpdateAnnotation),
+				"image-controller annotation should persist across reconciliations")
+			Expect(annotations[ImageControllerUpdateAnnotation]).To(Equal("true"))
+		})
+
+		It("should NOT re-apply annotation after image-controller removes it", func() {
+			// First reconcile: Set owner reference
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Second reconcile: Create resources including ImageRepository with annotation
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify ImageRepository was created with the annotation
+			imageRepoName := types.NamespacedName{
+				Namespace: testNs,
+				Name:      "cool-comp1-repo-2-2-0",
+			}
+			imageRepo := &unstructured.Unstructured{}
+			imageRepo.SetAPIVersion("appstudio.redhat.com/v1alpha1")
+			imageRepo.SetKind("ImageRepository")
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+
+			annotations := imageRepo.GetAnnotations()
+			Expect(annotations).To(HaveKey(ImageControllerUpdateAnnotation))
+
+			// Simulate image-controller processing by removing the annotation
+			delete(annotations, ImageControllerUpdateAnnotation)
+			imageRepo.SetAnnotations(annotations)
+			err = k8sClient.Update(ctx, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify annotation was removed
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+			annotations = imageRepo.GetAnnotations()
+			Expect(annotations).NotTo(HaveKey(ImageControllerUpdateAnnotation),
+				"annotation should be removed to simulate image-controller processing")
+
+			// Third reconcile: project-controller should NOT restore the annotation
+			// because the live ImageRepository doesn't have it (image-controller removed it)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the annotation is still absent (not restored)
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+			annotations = imageRepo.GetAnnotations()
+			Expect(annotations).NotTo(HaveKey(ImageControllerUpdateAnnotation),
+				"project-controller should NOT restore annotation after image-controller removes it")
+		})
+
+		It("REGRESSION: should apply annotation even when Component has templated containerImage", func() {
+			// This tests Yftach's regression: if Component is created with containerImage
+			// already set from the template, we should STILL apply the annotation on
+			// ImageRepository's first creation.
+			// With the new logic (checking live ImageRepository), this should now PASS.
+
+			// Manually create Component with containerImage already set (simulating template)
+			component := &unstructured.Unstructured{}
+			component.SetAPIVersion("appstudio.redhat.com/v1alpha1")
+			component.SetKind("Component")
+			component.SetNamespace(testNs)
+			component.SetName("cool-comp1-2-2-0")
+
+			// Set containerImage BEFORE ImageRepository is created (like a template would)
+			err := unstructured.SetNestedField(component.Object, "cool-app-2-2-0", "spec", "application")
+			Expect(err).NotTo(HaveOccurred())
+			err = unstructured.SetNestedField(component.Object, "quay.io/pre-set/image:v1", "spec", "containerImage")
+			Expect(err).NotTo(HaveOccurred())
+			err = unstructured.SetNestedMap(component.Object, map[string]interface{}{
+				"git": map[string]interface{}{
+					"url": "https://github.com/example/repo",
+				},
+			}, "spec", "source")
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Create(ctx, component)
+			Expect(err).NotTo(HaveOccurred())
+
+			// First reconcile: Set owner reference
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Second reconcile: Create ImageRepository
+			// At this point, Component.spec.containerImage is ALREADY set
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify ImageRepository was created WITH the annotation
+			// (This PASSES with the new logic because we check live ImageRepository, not Component)
+			imageRepoName := types.NamespacedName{
+				Namespace: testNs,
+				Name:      "cool-comp1-repo-2-2-0",
+			}
+			imageRepo := &unstructured.Unstructured{}
+			imageRepo.SetAPIVersion("appstudio.redhat.com/v1alpha1")
+			imageRepo.SetKind("ImageRepository")
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+
+			annotations := imageRepo.GetAnnotations()
+			Expect(annotations).NotTo(BeNil(), "ImageRepository should have annotations")
+			Expect(annotations).To(HaveKey(ImageControllerUpdateAnnotation),
+				"annotation MUST be present even though Component already has containerImage from template")
+			Expect(annotations[ImageControllerUpdateAnnotation]).To(Equal("true"))
+		})
+	})
+})

--- a/internal/controller/projectdevelopmentstream_controller_test.go
+++ b/internal/controller/projectdevelopmentstream_controller_test.go
@@ -470,5 +470,193 @@ var _ = Describe("ImageRepository annotation persistence", func() {
 				"annotation MUST be present even though Component already has containerImage from template")
 			Expect(annotations[ImageControllerUpdateAnnotation]).To(Equal("true"))
 		})
+
+		It("should treat empty-string annotation as removed by image-controller", func() {
+			// Test case 1 from Yftach: empty-string annotation should be treated the same as absent.
+			// If image-controller sets update-component-image: "" instead of deleting it,
+			// project-controller should NOT re-apply it from the template.
+
+			// First reconcile: Set owner reference
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Second reconcile: Create resources including ImageRepository with annotation
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify ImageRepository was created
+			imageRepoName := types.NamespacedName{
+				Namespace: testNs,
+				Name:      "cool-comp1-repo-2-2-0",
+			}
+			imageRepo := &unstructured.Unstructured{}
+			imageRepo.SetAPIVersion("appstudio.redhat.com/v1alpha1")
+			imageRepo.SetKind("ImageRepository")
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Simulate image-controller setting the annotation to empty string instead of deleting it
+			annotations := imageRepo.GetAnnotations()
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations[ImageControllerUpdateAnnotation] = ""
+			imageRepo.SetAnnotations(annotations)
+			err = k8sClient.Update(ctx, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify annotation is now empty string
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+			annotations = imageRepo.GetAnnotations()
+			Expect(annotations[ImageControllerUpdateAnnotation]).To(Equal(""),
+				"annotation should be set to empty string to simulate image-controller behavior variant")
+
+			// Third reconcile: project-controller should NOT restore the annotation to "true"
+			// because empty string is treated as "processed" (same as absent)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the annotation is still empty (not restored to "true")
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+			annotations = imageRepo.GetAnnotations()
+			Expect(annotations[ImageControllerUpdateAnnotation]).To(Equal(""),
+				"project-controller should NOT change empty-string annotation back to 'true'")
+		})
+
+		It("should NOT restore annotation after premature loss before image-controller processes it", func() {
+			// Test case 2 from Yftach: if the annotation is lost (deleted by an external actor or bug)
+			// before image-controller processes it, project-controller should NOT restore it.
+			// This documents the current no-self-heal behavior and prevents accidental churn reintroduction.
+
+			// First reconcile: Set owner reference
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Second reconcile: Create resources including ImageRepository with annotation
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify ImageRepository was created with the annotation
+			imageRepoName := types.NamespacedName{
+				Namespace: testNs,
+				Name:      "cool-comp1-repo-2-2-0",
+			}
+			imageRepo := &unstructured.Unstructured{}
+			imageRepo.SetAPIVersion("appstudio.redhat.com/v1alpha1")
+			imageRepo.SetKind("ImageRepository")
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+
+			annotations := imageRepo.GetAnnotations()
+			Expect(annotations).To(HaveKey(ImageControllerUpdateAnnotation))
+			Expect(annotations[ImageControllerUpdateAnnotation]).To(Equal("true"))
+
+			// Simulate premature annotation loss (e.g., external actor, bug, or race)
+			// This happens BEFORE image-controller has a chance to process it
+			delete(annotations, ImageControllerUpdateAnnotation)
+			imageRepo.SetAnnotations(annotations)
+			err = k8sClient.Update(ctx, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify annotation was removed
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+			annotations = imageRepo.GetAnnotations()
+			Expect(annotations).NotTo(HaveKey(ImageControllerUpdateAnnotation),
+				"annotation should be absent to simulate premature loss")
+
+			// Third reconcile: project-controller should NOT restore the annotation
+			// This is the documented behavior: no self-healing to avoid churn
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the annotation is still absent (not restored from template)
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+			annotations = imageRepo.GetAnnotations()
+			Expect(annotations).NotTo(HaveKey(ImageControllerUpdateAnnotation),
+				"project-controller should NOT restore annotation after premature loss (no self-heal)")
+		})
+
+		It("should handle full bootstrap lifecycle with sequential reconciles", func() {
+			// Test case 4 from Yftach (optional): end-to-end bootstrap sequence
+			// This consolidates the happy path into a single spec to catch regressions
+			// where one step breaks in isolation.
+
+			imageRepoName := types.NamespacedName{
+				Namespace: testNs,
+				Name:      "cool-comp1-repo-2-2-0",
+			}
+
+			// Step 1: First reconcile - Set owner reference
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Step 2: Second reconcile - Create ImageRepository with annotation
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify: ImageRepository created with annotation
+			imageRepo := &unstructured.Unstructured{}
+			imageRepo.SetAPIVersion("appstudio.redhat.com/v1alpha1")
+			imageRepo.SetKind("ImageRepository")
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+			annotations := imageRepo.GetAnnotations()
+			Expect(annotations).To(HaveKey(ImageControllerUpdateAnnotation))
+			Expect(annotations[ImageControllerUpdateAnnotation]).To(Equal("true"),
+				"annotation should be present after bootstrap")
+
+			// Step 3: Third reconcile - Annotation still present (image-controller hasn't processed yet)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify: Annotation preserved across reconciles
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+			annotations = imageRepo.GetAnnotations()
+			Expect(annotations).To(HaveKey(ImageControllerUpdateAnnotation))
+			Expect(annotations[ImageControllerUpdateAnnotation]).To(Equal("true"),
+				"annotation should persist while image-controller hasn't acted")
+
+			// Step 4: Simulate image-controller completion (remove annotation, set containerImage on Component)
+			delete(annotations, ImageControllerUpdateAnnotation)
+			imageRepo.SetAnnotations(annotations)
+			err = k8sClient.Update(ctx, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Also update Component to simulate full image-controller workflow
+			component := &unstructured.Unstructured{}
+			component.SetAPIVersion("appstudio.redhat.com/v1alpha1")
+			component.SetKind("Component")
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: testNs,
+				Name:      "cool-comp1-2-2-0",
+			}, component)
+			if err == nil {
+				_ = unstructured.SetNestedField(component.Object, "quay.io/konflux/cool-comp1:latest", "spec", "containerImage")
+				_ = k8sClient.Update(ctx, component)
+			}
+
+			// Verify: Annotation removed
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+			annotations = imageRepo.GetAnnotations()
+			Expect(annotations).NotTo(HaveKey(ImageControllerUpdateAnnotation),
+				"annotation should be absent after image-controller processing")
+
+			// Step 5: Fourth reconcile - Should NOT restore annotation
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: testNsN})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Final verification: Annotation stays absent
+			err = k8sClient.Get(ctx, imageRepoName, imageRepo)
+			Expect(err).NotTo(HaveOccurred())
+			annotations = imageRepo.GetAnnotations()
+			Expect(annotations).NotTo(HaveKey(ImageControllerUpdateAnnotation),
+				"annotation should NOT be restored after image-controller completes")
+		})
 	})
 })

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -37,6 +37,11 @@ var supportedResourceTypes = []struct {
 	untouchableFields [][]string
 	// Fields that should be set only if creating new resources
 	createOnlyFields [][]string
+	// Fields that should only be included in the desired state if they exist in the live resource.
+	// This is used for fields that signal one-time processing by another controller.
+	// The field will be applied on creation, but on updates it will only be included if present
+	// in the live resource (preventing re-application after another controller removes it).
+	liveStateConditionalFields [][]string
 	// A field of the resource that points to its owner object. If nil, an
 	// owner record would not be set.
 	ownerNameField []string
@@ -100,6 +105,9 @@ var supportedResourceTypes = []struct {
 		},
 		templateAbleFields: [][]string{
 			{"spec", "image", "name"},
+			{"metadata", "annotations", "image-controller.appstudio.redhat.com/update-component-image"},
+		},
+		liveStateConditionalFields: [][]string{
 			{"metadata", "annotations", "image-controller.appstudio.redhat.com/update-component-image"},
 		},
 		ownerNameField: []string{"metadata", "labels", "appstudio.redhat.com/component"},
@@ -340,4 +348,15 @@ func RemoveCreateOnlyFields(resource *unstructured.Unstructured) {
 			return
 		}
 	}
+}
+
+// GetLiveStateConditionalFields returns the list of fields that should only be included
+// if they exist in the live resource. Returns nil if the resource type doesn't have any.
+func GetLiveStateConditionalFields(resource *unstructured.Unstructured) [][]string {
+	for _, srt := range supportedResourceTypes {
+		if findGVK(srt.supportedAPIs, resource.GroupVersionKind()) {
+			return srt.liveStateConditionalFields
+		}
+	}
+	return nil
 }

--- a/internal/template/resources.go
+++ b/internal/template/resources.go
@@ -100,8 +100,6 @@ var supportedResourceTypes = []struct {
 		},
 		templateAbleFields: [][]string{
 			{"spec", "image", "name"},
-		},
-		createOnlyFields: [][]string{
 			{"metadata", "annotations", "image-controller.appstudio.redhat.com/update-component-image"},
 		},
 		ownerNameField: []string{"metadata", "labels", "appstudio.redhat.com/component"},

--- a/skills/add-template-field/SKILL.md
+++ b/skills/add-template-field/SKILL.md
@@ -37,6 +37,7 @@ literals leak into created CRs.
 | Free-form string (URLs, image refs, descriptions, paths with `/`) | `templateAbleFields` | None |
 | Must never be controller-managed | `untouchableFields` | Stripped before apply |
 | Set only on create | `createOnlyFields` | Stripped on update |
+| One-time cross-controller signal | `liveStateConditionalFields` | Conditionally included based on live state |
 
 **Pitfall:** `spec.image.name` on ImageRepository is `templateAbleFields`, not name
 fields — it may contain `/`.
@@ -57,7 +58,7 @@ Copy and track:
 
 ```
 - [ ] 1. Confirm field path and resource kind
-- [ ] 2. Pick category (name vs general vs untouchable vs createOnly)
+- [ ] 2. Pick category (name vs general vs untouchable vs createOnly vs liveStateConditional)
 - [ ] 3. Add path to supportedResourceTypes in resources.go
 - [ ] 4. Update config/samples fixtures
 - [ ] 5. Run make test (required)


### PR DESCRIPTION
Fixes nudge PR creation by preventing project-controller from removing the image-controller annotation before it can be processed. Adds conditional logic to only apply the annotation when Component.spec.containerImage is not yet set, avoiding reconciliation churn.

Fixes: https://github.com/konflux-ci/project-controller/issues/969