### PR TITLE
renovate: disable indirect Go module updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,16 +54,9 @@
       ]
     },
     {
-      "description": "Disable major version updates for indirect Go dependencies since they are resolved by go mod tidy based on direct dependency requirements",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepTypes": [
-        "indirect"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
+      "description": "Disable Renovate updates for indirect Go dependencies since they are resolved by go mod tidy based on direct dependency requirements",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
       "enabled": false
     },
     {


### PR DESCRIPTION
## Summary
- Disable Renovate updates for indirect-only Go module dependencies via `gomod.packageRules`
- Replaces the previous major-only indirect disable rule

## Test plan
- [ ] Verify Renovate config is valid JSON
- [ ] Confirm MintMaker/Renovate no longer opens PRs for indirect-only gomod updates

Made with [Cursor](https://cursor.com)